### PR TITLE
Reduce swift-tools-version to 5.0.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
I am currently required to stay on Swift 5.0 for legacy reasons. It appears that the project compiles just fine with Swift 5.0, so I would appreciate if you could accept this patch. That would help me avoid having to maintain a fork of this repo with that patch applied.

(Also see https://github.com/christophhagen/CCurve25519/pull/1.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/christophhagen/curve25519/4)
<!-- Reviewable:end -->
